### PR TITLE
Makes i to f for contextual features available for lookup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git lfs pull
 
 ## Initialization
 
-_Note: This will take a few minutes to initalize. An sqlite database of about 5.2 GB is produced._
+_Note: This will take a few minutes to initalize. An sqlite database of about 5.7 GB is produced._
 
 _Note: The initialization uses alive_progress to show progress. You can get it by 'pip3 install alive_progress'._
 

--- a/initialize.py
+++ b/initialize.py
@@ -18,7 +18,4 @@
 import category_builder_util as util
 
 if __name__ == "__main__":
-  util.create_db(data_dir=".")
-
-
-
+    util.create_db(data_dir=".")


### PR DESCRIPTION
Item to feature for contextual features was only in f to i.
Contextual features are co-occuurence based and symmetrical (unlike syntactic) features, and were not repeated.

Now, an additional table is added to cb.db containing these.